### PR TITLE
Porting LiveCV to OSX.

### DIFF
--- a/config.pro
+++ b/config.pro
@@ -104,5 +104,11 @@ unix{
 
 }
 
+macx {
+# This solves failure to find OpenCV.
+QT_CONFIG -= no-pkg-config
+# And this solves a linking error (XCode quirkies).
+QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
+}
 
 }


### PR DESCRIPTION
This changes will ensure that LiveCV will compile and link correctly in OSX (10.10.5, XCode 7.0.1).

Next: the runtime patches.

Signed-off-by: Adenilson Cavalcanti <cavalcantii@gmail.com>